### PR TITLE
Fix teleproxy.mk when CGO_ENABLED=0 on macOS

### DIFF
--- a/teleproxy.mk
+++ b/teleproxy.mk
@@ -26,6 +26,9 @@ KUBE_URL = https://kubernetes/api/
 
 TELEPROXY ?= $(build-aux.bindir)/teleproxy
 $(eval $(call build-aux.bin-go.rule,teleproxy,github.com/datawire/teleproxy/cmd/teleproxy))
+ifeq ($(GOHOSTOS),darwin)
+$(build-aux.bindir)/.teleproxy.stamp: CGO_ENABLED = 1
+endif
 # override the rule for .teleproxy.stamp -> teleproxy
 $(build-aux.bindir)/teleproxy: $(build-aux.bindir)/%: $(build-aux.bindir)/.%.stamp $(COPY_IFCHANGED)
 	sudo $(COPY_IFCHANGED) $< $@

--- a/tests/common.bash
+++ b/tests/common.bash
@@ -2,7 +2,7 @@
 
 common_setup() {
 	test_tmpdir="$(mktemp -d)"
-	ln -s "$BATS_TEST_DIRNAME/.." "$test_tmpdir/build-aux"
+	cp -a "$BATS_TEST_DIRNAME/.." "$test_tmpdir/build-aux"
 	cd "$test_tmpdir"
 	cat >Makefile <<-'__EOT__'
 		.DEFAULT_GOAL = all

--- a/tests/prelude.bats
+++ b/tests/prelude.bats
@@ -130,9 +130,6 @@ load common
 		# things are clean.
 		skip
 	fi
-	# Let's not work with a symlink for this test
-	rm "$test_tmpdir/build-aux"
-	cp -a "$BATS_TEST_DIRNAME/.." "$test_tmpdir/build-aux"
 	(cd build-aux && git clean -fdx)
 
 	cat >>Makefile <<-'__EOT__'

--- a/tests/teleproxy.bats
+++ b/tests/teleproxy.bats
@@ -6,3 +6,9 @@ load common
 	check_go_executable teleproxy.mk TELEPROXY
 	# TODO: Check that $TELEPROXY behaves correctly
 }
+
+@test "teleproxy.mk: TELEPROXY (CGO_ENABLED=0)" {
+	echo 'export CGO_ENABLED = 0' >> Makefile
+	check_go_executable teleproxy.mk TELEPROXY
+	# TODO: Check that $TELEPROXY behaves correctly
+}


### PR DESCRIPTION
I'd previously fixed this, but it got lost in a bad merge.

So add a test for it this time.